### PR TITLE
add colorToRgbaFloat

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ StyleDictionary.registerTransform({
   - [color/hexAlpha](#colorhexAlpha)
   - [color/hex](#colorhex)
   - [color/rgba](#colorrgba)
+  - [color/rgbaFloat](#colorrgbafloat)
   - [shadow/css](#shadowcss)
   - [font/css](#fontcss)
   - [fontFamily/css](#fontFamilycss)
@@ -477,6 +478,58 @@ const myStyleDictionary = StyleDictionary.extend({
     blue: {
       500: { 
         value: "rgba(13, 112, 230, 0.4)",
+        $type: "color"
+      }
+    }
+  }
+}
+```
+
+### color/rgbaFloat
+
+This `value` transformer replaces the value of a token with a `$type` or `type` of `color` with an `rgba float` object.
+This is helpful for tools and platforms and use float rgba values where the `r`, `g`, `b` and `a` values go from `0` to `1`. For example when preparing tokens to be imported into Figma.
+
+```js
+const myStyleDictionary = StyleDictionary.extend({
+  "platforms": {
+    "json": {
+      "transforms": ['color/rgbaFloat'],
+      "files": [{
+        // ...
+      }]
+    }
+  }
+});
+```
+##### Before transformation
+
+```js
+{
+  colors: {
+    blue: {
+      500: { 
+        value: "#0D70E666",
+        $type: "color"
+      }
+    }
+  }
+}
+``` 
+
+##### After transformation
+
+```js
+{
+  colors: {
+    blue: {
+      500: { 
+        value: {
+          r: 0.051, 
+          g: 0.439, 
+          b: 0.902, 
+          a: 0.4
+        },
         $type: "color"
       }
     }

--- a/__tests__/build.test.js
+++ b/__tests__/build.test.js
@@ -10,6 +10,7 @@ describe('index.js', () => {
     expect(StyleDictionary.transform["color/hex"]).toBeDefined();
     expect(StyleDictionary.transform["color/rgba"]).toBeDefined();
     expect(StyleDictionary.transform["color/rgbAlpha"]).toBeDefined();
+    expect(StyleDictionary.transform["color/rgbaFloat"]).toBeDefined();
     expect(StyleDictionary.transform["color/hexAlpha"]).toBeDefined();
     expect(StyleDictionary.transform["name/pathToDotNotation"]).toBeDefined();
     expect(StyleDictionary.transform["shadow/css"]).toBeDefined();

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -18,6 +18,7 @@ describe('index.ts', () => {
     expect(StyleDictionary.transform['color/hex']).toBeDefined()
     expect(StyleDictionary.transform['color/rgba']).toBeDefined()
     expect(StyleDictionary.transform['color/rgbAlpha']).toBeDefined()
+    expect(StyleDictionary.transform['color/rgbaFloat']).toBeDefined()
     expect(StyleDictionary.transform['color/hexAlpha']).toBeDefined()
     expect(StyleDictionary.transform['name/pathToDotNotation']).toBeDefined()
     expect(StyleDictionary.transform['shadow/css']).toBeDefined()

--- a/__tests__/transformer/color-to-rgba-float.test.ts
+++ b/__tests__/transformer/color-to-rgba-float.test.ts
@@ -1,0 +1,121 @@
+import StyleDictionary from 'style-dictionary'
+import { colorToRgbaFloat } from '../../src/transformer/color-to-rgba-float'
+import { getMockToken } from '../../src/testUtilities/getMockToken'
+
+describe('Transformer: colorToRgbaFloat', () => {
+  it('transforms `hex3`, `hex6`, and `hex8` tokens to rgb float value', () => {
+    const input = [{ value: '#123' }, { value: '#343434' }, { value: '#34343466' }]
+    const expectedOutput = [
+      {
+        r: 0.06666666666666667,
+        g: 0.13333333333333333,
+        b: 0.2,
+        a: 1,
+      },
+      {
+        r: 0.20392156862745098,
+        g: 0.20392156862745098,
+        b: 0.20392156862745098,
+        a: 1,
+      },
+      {
+        r: 0.20392156862745098,
+        g: 0.20392156862745098,
+        b: 0.20392156862745098,
+        a: 0.4,
+      },
+    ]
+    expect(input.map(item => colorToRgbaFloat.transformer(item as StyleDictionary.TransformedToken, {}))).toStrictEqual(expectedOutput)
+  })
+
+  it('transforms `rgb` and `rgba` to rgb float value', () => {
+    const input = [{ value: 'rgb(100,200,255)' }, { value: 'rgba(100,200,255, .4)' }]
+    const expectedOutput = [
+      {
+        r: 0.39215686274509803,
+        g: 0.7843137254901961,
+        b: 1,
+        a: 1,
+      },
+      {
+        r: 0.39215686274509803,
+        g: 0.7843137254901961,
+        b: 1,
+        a: 0.4,
+      },
+    ]
+    expect(input.map(item => colorToRgbaFloat.transformer(item as StyleDictionary.TransformedToken, {}))).toStrictEqual(expectedOutput)
+  })
+
+  it('transforms `color` tokens including alpha value', () => {
+    expect(
+      [
+        getMockToken({ value: '#343434', alpha: 0.4 }),
+        getMockToken({ value: '#34343466', alpha: 0.9 }),
+        getMockToken({ value: 'rgb(100,200,255)', alpha: 0.4 }),
+        getMockToken({ value: 'rgba(100,200,255,0.8)', alpha: 0.4 }),
+      ].map(item => colorToRgbaFloat.transformer(item as StyleDictionary.TransformedToken, {})),
+    ).toStrictEqual([
+      {
+        r: 0.20392156862745098,
+        g: 0.20392156862745098,
+        b: 0.20392156862745098,
+        a: 0.4,
+      },
+      {
+        r: 0.20392156862745098,
+        g: 0.20392156862745098,
+        b: 0.20392156862745098,
+        a: 0.9,
+      },
+      {
+        r: 0.39215686274509803,
+        g: 0.7843137254901961,
+        b: 1,
+        a: 0.4,
+      },
+      {
+        r: 0.39215686274509803,
+        g: 0.7843137254901961,
+        b: 1,
+        a: 0.4,
+      },
+    ])
+  })
+
+  it('it forwards `rgb float` values', () => {
+    const input = [
+      {
+        value: {
+          r: 0.39215686274509803,
+          g: 0.7843137254901961,
+          b: 1,
+          a: 1,
+        },
+      },
+      {
+        value: {
+          r: 0.39215686274509803,
+          g: 0.7843137254901961,
+          b: 1,
+          a: 0.4,
+        },
+      },
+    ]
+    const expectedOutput = [
+      {
+        r: 0.39215686274509803,
+        g: 0.7843137254901961,
+        b: 1,
+        a: 1,
+      },
+      {
+        r: 0.39215686274509803,
+        g: 0.7843137254901961,
+        b: 1,
+        a: 0.4,
+      },
+    ]
+    expect(input.map(item => colorToRgbaFloat.transformer(item as StyleDictionary.TransformedToken, {}))).toStrictEqual(expectedOutput)
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import { namePathToDotNotation } from './transformer/name-path-to-dot-notation'
 import { shadowCss } from './transformer/shadow-css'
 import { cssExtended } from './transformGroups/cssExtended'
 import { gradientCss } from './transformer/gradient-css'
+import { colorToRgbaFloat } from './transformer/color-to-rgba-float'
 
 /**
  * Parsers
@@ -76,6 +77,11 @@ OrigialStyleDictionary.registerTransform({
 OrigialStyleDictionary.registerTransform({
   name: 'color/rgba',
   ...colorToRgba
+})
+
+OrigialStyleDictionary.registerTransform({
+  name: 'color/rgbaFloat',
+  ...colorToRgbaFloat
 })
 
 OrigialStyleDictionary.registerTransform({

--- a/src/testUtilities/getMockToken.ts
+++ b/src/testUtilities/getMockToken.ts
@@ -1,0 +1,25 @@
+import type StyleDictionary from 'style-dictionary'
+
+const mockTokenDefaults = {
+  name: 'tokenName',
+  path: ['path'],
+  original: {
+    value: 'originalValue',
+    attributes: {},
+  },
+  filePath: 'file.json',
+  isSource: true,
+  value: 'transformedValue',
+  attributes: {},
+}
+/**
+ *
+ * @param valueOverrides partial StyleDictionary.TransformedToken
+ * @returns StyleDictionary.TransformedToken - a merge of {@link mockTokenDefaults} and any valid properties provided in the valueOverrides param
+ */
+export const getMockToken = (valueOverrides: {
+  [key: keyof StyleDictionary.TransformedToken]: unknown
+}): StyleDictionary.TransformedToken => ({
+  ...mockTokenDefaults,
+  ...valueOverrides,
+})

--- a/src/transformer/color-to-rgba-float.ts
+++ b/src/transformer/color-to-rgba-float.ts
@@ -1,0 +1,51 @@
+import { toHex } from 'color2k'
+import { isColor } from '../filter/isColor'
+import type StyleDictionary from 'style-dictionary'
+
+const toRgbaFloat = (color: string, alpha?: number) => {
+  // get hex value from color string
+  const hex = toHex(color)
+  // retrieve spots from hex value (hex 3, hex 6 or hex 8)
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})?$/i.exec(hex) ?? ['00', '00', '00']
+  // return parsed rgba float object using alpha value from token, from hex code or defaults to 1
+  return {
+    r: parseInt(result[1], 16) / 255,
+    g: parseInt(result[2], 16) / 255,
+    b: parseInt(result[3], 16) / 255,
+    a: alpha !== undefined ? alpha : parseInt(result[4], 16) / 255 || 1,
+  }
+}
+// sum up the values of all values in an array
+const sum = (array: unknown[]): number => array.reduce((acc: number, v: unknown) => acc + parseInt(`${v}`), 0)
+
+const isRgbaFloat = (value: unknown) => {
+  if (
+    value &&
+    typeof value === `object` &&
+    'r' in value &&
+    'g' in value &&
+    'b' in value &&
+    sum(Object.values(value)) < 5
+  ) {
+    return true
+  }
+  return false
+}
+
+/**
+ * @description converts color tokens rgba float with values from 0 - 1
+ * @type value transformer — [StyleDictionary.ValueTransform](https://github.com/amzn/style-dictionary/blob/main/types/Transform.d.ts)
+ * @matcher matches all tokens of $type `color`
+ * @transformer returns a `rgb` float object
+ */
+export const colorToRgbaFloat: StyleDictionary.Transform = {
+  type: `value`,
+  transitive: true,
+  matcher: isColor,
+  transformer: (token: StyleDictionary.TransformedToken) => {
+    // skip if value is already rgb float
+    if (isRgbaFloat(token.value)) return token.value
+    // convert hex or rgb values to rgba float
+    return toRgbaFloat(token.value, token.alpha)
+  },
+}


### PR DESCRIPTION
Adds transformer for color to RGBA Float which can be used, e.g. for preparing tokens for Figma.