### PR TITLE
Fix Typo in Cubic Bezier Transformer and Update Tests

### DIFF
--- a/__tests__/transformer/color-alpha-to-hex.test.ts
+++ b/__tests__/transformer/color-alpha-to-hex.test.ts
@@ -9,7 +9,7 @@ describe('Transformer: colorAlphaToHex', () => {
       { value: '#343' },
       { value: '#343434' },
       { value: '#34343466' }
-    ].map(item => colorAlphaToHex.transformer(item as StyleDictionary.TransformedToken))).toStrictEqual([
+    ].map(item => colorAlphaToHex.transformer(item as StyleDictionary.TransformedToken, {}))).toStrictEqual([
       "#334433",
       "#343434",
       "#34343466"
@@ -20,7 +20,7 @@ describe('Transformer: colorAlphaToHex', () => {
     expect([
       { value: 'rgb(100,200,255)' },
       { value: 'rgba(100,200,255, .4)' }
-    ].map(item => colorAlphaToHex.transformer(item as StyleDictionary.TransformedToken))).toStrictEqual([
+    ].map(item => colorAlphaToHex.transformer(item as StyleDictionary.TransformedToken, {}))).toStrictEqual([
       "#64c8ff",
       "#64c8ff66",
     ]);
@@ -31,7 +31,7 @@ describe('Transformer: colorAlphaToHex', () => {
       { value: '#343434', alpha: .4 },
       { value: '#34343466', alpha: .2 }
       // @ts-expect-error: fake token for test causes error
-    ].map(item => colorAlphaToHex.transformer(item))).toStrictEqual([
+    ].map(item => colorAlphaToHex.transformer(item, {}))).toStrictEqual([
       "#34343466",
       "#34343433"
     ]);

--- a/__tests__/transformer/color-alpha-to-rgba.test.ts
+++ b/__tests__/transformer/color-alpha-to-rgba.test.ts
@@ -8,7 +8,7 @@ describe('Transformer: colorToRgba', () => {
       { value: '#343' },
       { value: '#343434' },
       { value: '#34343466' }
-    ].map(item => colorAlphaToRgba.transformer(item as StyleDictionary.TransformedToken))).toStrictEqual([
+    ].map(item => colorAlphaToRgba.transformer(item as StyleDictionary.TransformedToken, {}))).toStrictEqual([
       "rgba(51, 68, 51, 1)",
       "rgba(52, 52, 52, 1)",
       "rgba(52, 52, 52, 0.4)"
@@ -20,7 +20,7 @@ describe('Transformer: colorToRgba', () => {
       { value: 'rgb(100,200,255)' },
       { value: 'rgba(100,200,255, .4)' },
       { value: 'rgba(100,200,255, 0)' }
-    ].map(item => colorAlphaToRgba.transformer(item as StyleDictionary.TransformedToken))).toStrictEqual([
+    ].map(item => colorAlphaToRgba.transformer(item as StyleDictionary.TransformedToken, {}))).toStrictEqual([
       'rgba(100, 200, 255, 1)',
       'rgba(100, 200, 255, 0.4)',
       'rgba(100, 200, 255, 0)'
@@ -33,7 +33,7 @@ describe('Transformer: colorToRgba', () => {
       { value: '#343434cc', alpha: .2 },
       { value: '#343434', alpha: 0 }
       // @ts-expect-error: fake token for test causes error
-    ].map(item => colorAlphaToRgba.transformer(item))).toStrictEqual([
+    ].map(item => colorAlphaToRgba.transformer(item, {}))).toStrictEqual([
       "rgba(52, 52, 52, 0.4)",
       "rgba(52, 52, 52, 0.2)",
       "rgba(52, 52, 52, 0)",

--- a/__tests__/transformer/color-to-hex.test.ts
+++ b/__tests__/transformer/color-to-hex.test.ts
@@ -8,7 +8,7 @@ describe('Transformer: colorToHex', () => {
       { value: '#343' },
       { value: '#343434' },
       { value: '#34343466' }
-    ].map(item => colorToHex.transformer(item as StyleDictionary.TransformedToken))).toStrictEqual([
+    ].map(item => colorToHex.transformer(item as StyleDictionary.TransformedToken, {}))).toStrictEqual([
       "#334433",
       "#343434",
       "#34343466"
@@ -19,7 +19,7 @@ describe('Transformer: colorToHex', () => {
     expect([
       { value: 'rgb(100,200,255)' },
       { value: 'rgba(100,200,255, .4)' }
-    ].map(item => colorToHex.transformer(item as StyleDictionary.TransformedToken))).toStrictEqual([
+    ].map(item => colorToHex.transformer(item as StyleDictionary.TransformedToken, {}))).toStrictEqual([
       "#64c8ff",
       "#64c8ff66",
     ]);

--- a/__tests__/transformer/color-to-rgb.test.ts
+++ b/__tests__/transformer/color-to-rgb.test.ts
@@ -8,7 +8,7 @@ describe('Transformer: colorToHex', () => {
       { value: '#343' },
       { value: '#343434' },
       { value: '#34343466' }
-    ].map(item => colorToRgba.transformer(item as StyleDictionary.TransformedToken))).toStrictEqual([
+    ].map(item => colorToRgba.transformer(item as StyleDictionary.TransformedToken, {}))).toStrictEqual([
       "rgba(51, 68, 51, 1)",
       "rgba(52, 52, 52, 1)",
       "rgba(52, 52, 52, 0.4)"
@@ -19,7 +19,7 @@ describe('Transformer: colorToHex', () => {
     expect([
       { value: 'rgb(100,200,255)' },
       { value: 'rgba(100,200,255, .4)' }
-    ].map(item => colorToRgba.transformer(item as StyleDictionary.TransformedToken))).toStrictEqual([
+    ].map(item => colorToRgba.transformer(item as StyleDictionary.TransformedToken, {}))).toStrictEqual([
       "rgba(100, 200, 255, 1)",
       "rgba(100, 200, 255, 0.4)",
     ]);

--- a/__tests__/transformer/cubic-bezier-css.test.ts
+++ b/__tests__/transformer/cubic-bezier-css.test.ts
@@ -21,9 +21,9 @@ describe('Transformer: cubicBezierCss', () => {
   });
 
   it('transforms `cubicBezier` array tokens', () => {
-    expect(items.filter(cubicBezierCss.matcher as Matcher).map(item => cubicBezierCss.transformer(item))).toStrictEqual([
-      "cubic-bezier(0, 0, 0.5, 1);",
-      "cubic-bezier(0.5, 0, 1, 1);"
+    expect(items.filter(cubicBezierCss.matcher as Matcher).map(item => cubicBezierCss.transformer(item, {}))).toStrictEqual([
+      "cubic-bezier(0, 0, 0.5, 1)",
+      "cubic-bezier(0.5, 0, 1, 1)"
     ]);
   });
 })

--- a/__tests__/transformer/dimension-pixel-to-rem.test.ts
+++ b/__tests__/transformer/dimension-pixel-to-rem.test.ts
@@ -21,7 +21,7 @@ describe('Transformer: dimensionPixelToRem', () => {
   });
 
   it('transforms `dimension` tokens', () => {
-    expect(items.filter(dimensionPixelToRem.matcher as Matcher).map(item => dimensionPixelToRem.transformer(item))).toStrictEqual([
+    expect(items.filter(dimensionPixelToRem.matcher as Matcher).map(item => dimensionPixelToRem.transformer(item, {}))).toStrictEqual([
       "1.25rem"
     ]);
   })

--- a/__tests__/transformer/dimension-rem-to-pixel.test.ts
+++ b/__tests__/transformer/dimension-rem-to-pixel.test.ts
@@ -21,7 +21,7 @@ describe('Transformer: dimensionRemToPixel', () => {
   });
 
   it('transforms `dimension` tokens', () => {
-    expect(items.filter(dimensionRemToPixel.matcher as Matcher).map(item => dimensionRemToPixel.transformer(item))).toStrictEqual([
+    expect(items.filter(dimensionRemToPixel.matcher as Matcher).map(item => dimensionRemToPixel.transformer(item, {}))).toStrictEqual([
       "48px"
     ]);
   })

--- a/__tests__/transformer/dimension-to-pixelUnitless.test.ts
+++ b/__tests__/transformer/dimension-to-pixelUnitless.test.ts
@@ -17,7 +17,7 @@ describe('Transformer: dimensionPixelToRem', () => {
   }] as StyleDictionary.TransformedToken[];
 
   it('transforms `dimension` tokens', () => {
-    expect(items.filter(dimensionToPixelUnitless.matcher as Matcher).map(item => dimensionToPixelUnitless.transformer(item))).toStrictEqual([
+    expect(items.filter(dimensionToPixelUnitless.matcher as Matcher).map(item => dimensionToPixelUnitless.transformer(item, {}))).toStrictEqual([
       20,
       48,
     ]);

--- a/__tests__/transformer/font-css.test.ts
+++ b/__tests__/transformer/font-css.test.ts
@@ -30,7 +30,7 @@ describe('Transformer: fontFamily', () => {
   });
 
   it('transforms `fontFamily` array tokens', () => {
-    expect(items.filter(fontCss.matcher as Matcher).map(item => fontCss.transformer(item))).toStrictEqual([
+    expect(items.filter(fontCss.matcher as Matcher).map(item => fontCss.transformer(item, {}))).toStrictEqual([
       "italic 500 16px/22px Helvetica",
       "16px Helvetica",
     ]);

--- a/__tests__/transformer/font-family-css.test.ts
+++ b/__tests__/transformer/font-family-css.test.ts
@@ -21,7 +21,7 @@ describe('Transformer: fontFamily', () => {
   });
 
   it('transforms `fontFamily` array tokens', () => {
-    expect(items.filter(fontFamilyCss.matcher as Matcher).map(item => fontFamilyCss.transformer(item))).toStrictEqual([
+    expect(items.filter(fontFamilyCss.matcher as Matcher).map(item => fontFamilyCss.transformer(item, {}))).toStrictEqual([
       "helvetica, sans-serif, 'Helvetica Neue'"
     ]);
   });

--- a/__tests__/transformer/font-weight-to-number.test.ts
+++ b/__tests__/transformer/font-weight-to-number.test.ts
@@ -24,7 +24,7 @@ describe('Transformer: fontWeight', () => {
   });
 
   it('transforms `fontWeight` string to number', () => {
-    expect(items.filter(fontWeightToNumber.matcher as Matcher).map(item => fontWeightToNumber.transformer(item))).toStrictEqual([
+    expect(items.filter(fontWeightToNumber.matcher as Matcher).map(item => fontWeightToNumber.transformer(item, {}))).toStrictEqual([
       300,
       300
     ]);

--- a/__tests__/transformer/name-path-to-dot-notation.test.ts
+++ b/__tests__/transformer/name-path-to-dot-notation.test.ts
@@ -11,7 +11,7 @@ describe('Transformer: namePathToDotNotation', () => {
   }] as StyleDictionary.TransformedToken[];
 
   it('transforms names to dot notation', () => {
-    expect(items.map(item => namePathToDotNotation.transformer(item))).toStrictEqual([
+    expect(items.map(item => namePathToDotNotation.transformer(item, {}))).toStrictEqual([
       "base.color.red",
       "base.red",
     ]);

--- a/__tests__/transformer/shadow-css.test.ts
+++ b/__tests__/transformer/shadow-css.test.ts
@@ -24,7 +24,7 @@ describe('Transformer: shadowCss', () => {
   });
 
   it('transforms `shadow` tokens', () => {
-    expect(items.filter(shadowCss.matcher as Matcher).map(item => shadowCss.transformer(item))).toStrictEqual([
+    expect(items.filter(shadowCss.matcher as Matcher).map(item => shadowCss.transformer(item, {}))).toStrictEqual([
       "0px 0px 0px 3px #00000066"
     ]);
   });

--- a/src/transformer/cubic-bezier-css.ts
+++ b/src/transformer/cubic-bezier-css.ts
@@ -13,5 +13,5 @@ export const cubicBezierCss: StyleDictionary.Transform = {
   transitive: true,
   matcher: (token: StyleDictionary.TransformedToken) => isCubicBezier(token) && Array.isArray(token.value),
   transformer: ({ value: [x1, y1, x2, y2] }: { value: TokenCubicBezier }) =>
-    `cubic-bezier(${x1}, ${y1}, ${x2}, ${y2});`
+    `cubic-bezier(${x1}, ${y1}, ${x2}, ${y2})`
 }


### PR DESCRIPTION
This PR addresses two minor issues:

1. For the cubic-bezier transformer, we are getting this output (note the duplicate semi colons): 
![image](https://github.com/lukasoppermann/style-dictionary-utils/assets/56580725/eacee248-3455-42c2-8afb-a380e30aff9b)

2. The tests originally did not supply a second argument. Thus, whenever I would run the tests in my console, all of them would fail because of the lack of a second argument. In this PR, I added a second argument (an empty object).
