### PR TITLE
Update README with JSON5 prettier documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,17 +120,17 @@ This parser parses `.json` with [w3c design tokens](https://github.com/design-to
 
 This means the following files can be used with this parser.
 
-```js
+```json
 {
   "token": {
-    value: "#223344",
-    type: "color",
-    description: "token description"
+    "value": "#223344",
+    "type": "color",
+    "description": "token description"
   },
   "w3cToken": {
-    $value: "#223344",
-    $type: "color",
-    $description: "token description"
+    "$value": "#223344",
+    "$type": "color",
+    "$description": "token description"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -162,6 +162,20 @@ StyleDictionary.registerParser(w3cTokenJson5Parser)
 
 Make sure to install [`json5`](https://json5.org/) by running `npm i -D json5`.
 
+If you’re using [Prettier](https://prettier.io/), be aware that the default configuration removes [quote props](https://prettier.io/docs/en/options.html#quote-props), which are needed in `$type` and `$value` props in order to parse the tokens.
+
+Here’s an example of a prettier config that overrides the default:
+
+```yaml
+semi: false
+singleQuote: true
+overrides:
+  - files: '*.json[c|5]'
+    options:
+      quoteProps: preserve
+      singleQuote: false
+```
+
 ## 📑 Formats
 
 ### javascript/esm


### PR DESCRIPTION
The Prettier default configuration prevents tokens from being parsed. Added a configuration example to the README, and also updated the token JSON example with JSON syntax highlighting and quotes around the props. 

Thanks for your great work, we use this package to parse Figma variables for an upcoming Equinor Design System workshop we’re creating for an internal developer conference in September.