### PR TITLE
Parse JSON5 without prop quotes

### DIFF
--- a/__tests__/parser/w3c-token-json5-parser.test.ts
+++ b/__tests__/parser/w3c-token-json5-parser.test.ts
@@ -56,7 +56,7 @@ describe('Parser: w3c token json5 parser', () => {
     expect(w3cTokenJson5Parser.parse({ contents: '' })).toStrictEqual({});
   });
 
-  it('parses single and double quotes', () => {
+  it('parses single, double and no quotes', () => {
     expect(w3cTokenJson5Parser.parse({
       contents: `{
       "color": {
@@ -68,6 +68,12 @@ describe('Parser: w3c token json5 parser', () => {
       'colorTwo': {
         '$value' : 'red',
         '$description' : 'another red color',
+        '$type' : 'color',
+        'alpha': 0.5
+      },
+      'colorThree': {
+        $value : 'red',
+        $description : 'a third red color',
         '$type' : 'color',
         'alpha': 0.5
       }
@@ -84,7 +90,14 @@ describe('Parser: w3c token json5 parser', () => {
         value: 'red',
         $type: 'color',
         alpha: 0.5,
+      },
+      colorThree: {
+        comment: 'a third red color',
+        value: 'red',
+        $type: 'color',
+        alpha: 0.5,
       }
     });
   });
+  it
 });

--- a/src/parser/w3c-token-json5-parser.ts
+++ b/src/parser/w3c-token-json5-parser.ts
@@ -9,9 +9,9 @@ export const w3cTokenJson5Parser = {
   pattern: /\.json[c|5]?$|\.tokens\.json[c|5]?$|\.tokens$/,
   parse: ({ contents }: { contents: string }) => {
     // replace $value with value so that style dictionary recognizes it
-    const preparedContent = (contents || '{}').replace(/["']\$?value["']\s*:/g, '"value":')
+    const preparedContent = (contents || '{}').replace(/["']?\$?value["']?\s*:/g, '"value":')
       // convert $description to comment
-      .replace(/["']\$?description["']\s*:/g, '"comment":');
+      .replace(/["']?\$?description["']?\s*:/g, '"comment":');
     //
     return JSON5.parse(preparedContent);
   },


### PR DESCRIPTION
Since Prettier removes quotes around `$value` and `$description` in JSON5 token files, I assumed the problem was with the Prettier config itself. However, since both `$value` and `$description` are valid JSON5 props, the parser should be able to parse that.