### PR TITLE
Remove pathToDotNotation from the css/extended transformGroup

### DIFF
--- a/__tests__/transformGroup/cssExtended.test.ts
+++ b/__tests__/transformGroup/cssExtended.test.ts
@@ -16,7 +16,6 @@ describe('TransformGroup: css extended', () => {
     'font/css',
     'fontFamily/css',
     'fontWeight/number',
-    'name/pathToDotNotation',
     'cubicBezier/css',
     'border/css'
   ]

--- a/src/transformGroups/cssExtended.ts
+++ b/src/transformGroups/cssExtended.ts
@@ -9,7 +9,6 @@ export const cssExtended = {
     'font/css',
     'fontFamily/css',
     'fontWeight/number',
-    'name/pathToDotNotation',
     'cubicBezier/css',
     'border/css'
   ]


### PR DESCRIPTION
When using the `css/extended` transformGroup the `pathToDotNotation` transform results in CSS custom properties with dots instead of hyphens, such as `--some.variable` instead of `--some-variable`.