### PR TITLE
Handle the css color value of "transparent" in the colorToRgbaFloat transform

### DIFF
--- a/__tests__/transformer/color-to-rgba-float.test.ts
+++ b/__tests__/transformer/color-to-rgba-float.test.ts
@@ -47,6 +47,25 @@ describe('Transformer: colorToRgbaFloat', () => {
     expect(input.map(item => colorToRgbaFloat.transformer(item as StyleDictionary.TransformedToken, {}))).toStrictEqual(expectedOutput)
   })
 
+  it('transforms `named colors` and `transparent` to rgb float value', () => {
+    const input = [{ value: 'red' }, { value: 'transparent' }]
+    const expectedOutput = [
+      {
+        r: 1,
+        g: 0,
+        b: 0,
+        a: 1,
+      },
+      {
+        r: 0,
+        g: 0,
+        b: 0,
+        a: 0,
+      },
+    ]
+    expect(input.map(item => colorToRgbaFloat.transformer(item as StyleDictionary.TransformedToken, {}))).toStrictEqual(expectedOutput)
+  })
+
   it('transforms `color` tokens including alpha value', () => {
     expect(
       [

--- a/src/transformer/color-to-rgba-float.ts
+++ b/src/transformer/color-to-rgba-float.ts
@@ -12,7 +12,7 @@ const toRgbaFloat = (color: string, alpha?: number) => {
     r: parseInt(result[1], 16) / 255,
     g: parseInt(result[2], 16) / 255,
     b: parseInt(result[3], 16) / 255,
-    a: alpha !== undefined ? alpha : parseInt(result[4], 16) / 255 || 1,
+    a: alpha !== undefined ? alpha : (!isNaN(parseInt(result[4], 16) / 255)) ? (parseInt(result[4], 16) / 255) : 1,
   }
 }
 // sum up the values of all values in an array


### PR DESCRIPTION
Hey Lukas,

We noticed our `colorTransparent` token, which looks like

```json
"transparent": {
  "$value": "transparent",
  "$type": "color"
}
```

kept being output as `{"r":0,"g":0,"b":0,"a":1}`. 

Some digging revealed this is because `parseInt(result[4], 16) / 255` was returning `0`, and then falling back to the default `1`.

I have worked around this by explicitly setting the `alpha` property but thought this could be a good addition.

```json
"transparent": {
  "$value": "transparent",
  "alpha": 0,
  "$type": "color"
}
```
