### PR TITLE
bug: shadowCSS references returning `0 0 0 0 undefined` if value is `string`

### DIFF
--- a/src/transformer/shadow-css.ts
+++ b/src/transformer/shadow-css.ts
@@ -18,7 +18,5 @@ export const shadowCss: StyleDictionary.Transform = {
   transformer: ({ value }: { value: string | TokenShadow }) =>
   typeof value === 'string'
     ? value
-    : `${value.offsetX || 0} ${value.offsetY || 0} ${value.blur || 0} ${value.spread || 0} ${
-        value.color
-      }`,
+    : `${value.offsetX || 0} ${value.offsetY || 0} ${value.blur || 0} ${value.spread || 0} ${value.color}`,
 }

--- a/src/transformer/shadow-css.ts
+++ b/src/transformer/shadow-css.ts
@@ -15,6 +15,10 @@ export const shadowCss: StyleDictionary.Transform = {
   type: `value`,
   transitive: true,
   matcher: isShadow,
-  transformer: ({ value }: { value: TokenShadow }) =>
-    `${value.offsetX || 0} ${value.offsetY || 0} ${value.blur || 0} ${value.spread || 0} ${value.color}`
+  transformer: ({ value }: { value: string | TokenShadow }) =>
+  typeof value === 'string'
+    ? value
+    : `${value.offsetX || 0} ${value.offsetY || 0} ${value.blur || 0} ${value.spread || 0} ${
+        value.color
+      }`,
 }


### PR DESCRIPTION
When a shadow value is a reference and we want to output the value vs the reference, the value will already be transformed to a `string` vs a `type TokenShadow`. This fix is to add that check for a string and return the value is so.

**Input**
```json
{
  "shadow": {
    "100": {
      "$type": "shadow",
      "$value": {
        "color": "#00000014",
        "offsetX": "0px",
        "offsetY": "2px",
        "blur": "4px",
        "spread": "0px"
      }
    },
   "sheets": {
      "nonModal": { "$value": "{shadow.100}", "$type": "shadow" }
    }
  }
}
```

**Output before fix**
```css
:root {
  --shadow-100: 0px 2px 4px 0px #00000014;
  --shadow-sheets-nonModal: 0 0 0 0 undefined;
}
```

**Output _after_ fix**
```css
:root {
  --shadow-100: 0px 2px 4px 0px #00000014;
  --shadow-sheets-nonModal: 0px 2px 4px 0px #00000014;
}
```