### PR TITLE
fix: upgrade to 4.0.0-prelease.17, esm only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,7 +81,6 @@ typings/
 # Nuxt.js build / generate output
 .nuxt
 dist
-dist-cjs
 
 # Gatsby files
 .cache/

--- a/__tests__/build.test.js
+++ b/__tests__/build.test.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-import StyleDictionary from "../dist-cjs/index.js";
+import StyleDictionary from "../dist/index.js";
 
-describe('index.js', () => {  
+describe('index.js', () => {
   it("all formats are attached", () => {
     expect(StyleDictionary.format["javascript/esm"]).toBeDefined();
     expect(StyleDictionary.format["javascript/commonJs"]).toBeDefined();

--- a/eslint.tsconfig.json
+++ b/eslint.tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src/**/*.ts", "__tests__"],
-  "exclude": ["node_modules", "dist", "dist-cjs"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "style-dictionary": "4.0.0-prerelease.15"
+        "style-dictionary": "4.0.0-prerelease.17"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -7066,9 +7066,9 @@
       }
     },
     "node_modules/style-dictionary": {
-      "version": "4.0.0-prerelease.15",
-      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-4.0.0-prerelease.15.tgz",
-      "integrity": "sha512-kZ0qi0BClVsfh06+z/622VRKTcYdUvgSD6j1C/x50/Vvo2ndi/rcjyyTNmmwyqPMHp4lVgZ9BTUx0Mr9/+mzhA==",
+      "version": "4.0.0-prerelease.17",
+      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-4.0.0-prerelease.17.tgz",
+      "integrity": "sha512-cLIufEH0kje1C10EdUmGFm8jLc5CDQd7AAwtqnNnubCMJq03FMae1gKH/aqaPofvAASkf+nB4/LdYHm7ZY+V9A==",
       "hasInstallScript": true,
       "peer": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,28 +14,20 @@
     "node": ">=18.0.0"
   },
   "description": "Utilities to use in your style dictionary config",
-  "types": "dist/index.d.ts",
-  "module": "dist/index.js",
-  "main": "dist-cjs/index.js",
   "exports": {
-    ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts",
-      "require": "./dist-cjs/index.js"
-    }
+    ".": "./dist/index.js"
   },
   "files": [
     "dist/*",
-    "dist-cjs/*",
     "src/**/*.ts"
   ],
   "scripts": {
     "test": "NODE_OPTIONS=--experimental-vm-modules npx jest && npm run lint && tsc --noEmit",
     "lint": "npx eslint . --ext .ts",
     "fix": "npx eslint . --ext .ts --fix",
-    "clean:dist": "rm -rf dist/ && rm -rf dist-cjs/",
+    "clean:dist": "rm -rf dist/",
     "prebuild": "npm run clean:dist",
-    "build": "tsc && tsc -p tsconfig-esm.json",
+    "build": "tsc",
     "preversion": "npm run build && npm run test",
     "postversion": "git push --follow-tags"
   },
@@ -65,6 +57,6 @@
     "typescript": "^5.1.6"
   },
   "peerDependencies": {
-    "style-dictionary": "4.0.0-prerelease.15"
+    "style-dictionary": "4.0.0-prerelease.17"
   }
 }

--- a/tsconfig-esm.json
+++ b/tsconfig-esm.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "outDir": "./dist",
-  },
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,7 +49,7 @@
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./dist-cjs",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
@@ -98,7 +98,7 @@
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true,                                 /* Skip type checking all .d.ts files. */
+    // "skipLibCheck": true,                                 /* Skip type checking all .d.ts files. */
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
Changes

- Upgrade to latest pre.17 which also contains a few small type fixes
- Only 1 Typescript config, only publish as ESM, since style-dictionary v4 is ESM-only, remove dist-cjs everywhere
- disable skip lib check, style-dictionary doesn't need to be skipped anymore, the types should work

To answer your question about the /__tests__/ folder, I figured it's a good idea to also typecheck your tests, since this is where you often verify your public API of your lib, so it was indeed a conscious choice by me to add it.