### PR TITLE
[ReadMe]: Change transformer to transform prop name

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ StyleDictionary.registerTransform({
   name: 'transform/pxToRem',
   type: `value`,
   transitive: true,
-  transformer: () => // ...
+  transform: () => // ...
 })
 ```
 


### PR DESCRIPTION
Small correction to the docs here, looks like the property name should be `transform` here, otherwise the `registerTransform` function throws `transform must be a function` error.