### PR TITLE
Fix getValue import from isClamp filter

### DIFF
--- a/src/filter/isClamp.ts
+++ b/src/filter/isClamp.ts
@@ -1,5 +1,5 @@
 import {TransformedToken} from 'style-dictionary/types'
-import {getValue} from '../utilities/getValue'
+import {getValue} from '../utilities/getValue.js'
 /**
  * @name isClamp
  * @type filter


### PR DESCRIPTION
Importing the getValue method without the js extension is causing ERR_MODULE_NOT_FOUND. 